### PR TITLE
GstVideoOverlay

### DIFF
--- a/examples/x11embed/main.go
+++ b/examples/x11embed/main.go
@@ -1,0 +1,65 @@
+/*
+This example embeds a gstream pipeline output into an X11 window.
+Left-clicking the mouse in the window will start/pause the output video.
+*/
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/BurntSushi/xgb"
+	"github.com/BurntSushi/xgb/xproto"
+	"github.com/notedit/gst"
+)
+
+func main() {
+	pipeline, err := gst.ParseLaunch("videotestsrc ! xvimagesink sync=false name=output")
+	if err != nil {
+		log.Fatalf("ParseLaunch: %s", err)
+	}
+	e := pipeline.GetByName("output")
+	if e == nil {
+		log.Fatal("Output element not found")
+	}
+
+	X, err := xgb.NewConn()
+	if err != nil {
+		log.Fatalf("NewConn: %s", err)
+	}
+
+	setup := xproto.Setup(X)
+	screen := setup.DefaultScreen(X)
+	wid, _ := xproto.NewWindowId(X)
+	xproto.CreateWindow(X, screen.RootDepth, wid, screen.Root,
+		0, 0, 500, 500, 0,
+		xproto.WindowClassInputOutput, screen.RootVisual, 0, []uint32{})
+	xproto.ChangeWindowAttributes(X, wid,
+		xproto.CwBackPixel|xproto.CwEventMask,
+		[]uint32{
+			0xffffffff,
+			xproto.EventMaskStructureNotify | xproto.EventMaskButtonPress})
+	err = xproto.MapWindowChecked(X, wid).Check()
+	if err != nil {
+		log.Fatalf("Checked Error for mapping window %d: %s\n", wid, err)
+	}
+
+	isPlaying := false
+	for {
+		ev, xerr := X.WaitForEvent()
+		if ev == nil && xerr == nil {
+			fmt.Println("Both event and error are nil. Exiting...")
+			return
+		}
+		if _, ok := ev.(xproto.ButtonPressEvent); ok {
+			if isPlaying {
+				isPlaying = false
+				pipeline.SetState(gst.StatePaused)
+			} else {
+				isPlaying = true
+				e.VideoOverlaySetWindowHandle(uintptr(wid))
+				pipeline.SetState(gst.StatePlaying)
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/notedit/gst
 
 go 1.12
+

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/xgb v0.0.0-20200324125942-20f126ea2843 h1:3iF31c7rp7nGZVDv7YQ+VxOgpipVfPKotLXykjZmwM8=
+github.com/BurntSushi/xgb v0.0.0-20200324125942-20f126ea2843/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/BurntSushi/xgb v0.0.0-20200324125942-20f126ea2843 h1:3iF31c7rp7nGZVDv7YQ+VxOgpipVfPKotLXykjZmwM8=
-github.com/BurntSushi/xgb v0.0.0-20200324125942-20f126ea2843/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/gst.h
+++ b/gst.h
@@ -7,6 +7,7 @@
 
 
 
+
 typedef struct ElementUserData {
     guint64 callbackId;
 } ElementUserData;

--- a/overlay.go
+++ b/overlay.go
@@ -1,0 +1,37 @@
+package gst
+
+/*
+#cgo pkg-config: gstreamer-1.0 gstreamer-video-1.0
+#include "gst.h"
+#include <glib.h>
+#include <gst/video/videooverlay.h>
+*/
+import (
+	"C"
+)
+import "unsafe"
+
+// VideoOverlaySetWindowHandle will call the video overlay's set_window_handle method.
+// You should use this method to tell to an overlay to display video output to a specific window
+// (e.g. an XWindow on X11). Passing 0 as the handle will tell the overlay to stop using that
+// window and create an internal one. registers the windowID for video output of the element.
+func (e *Element) VideoOverlaySetWindowHandle(windowID uintptr) {
+	C.gst_video_overlay_set_window_handle((*C.GstVideoOverlay)(unsafe.Pointer(e.GstElement)), (C.guintptr)(windowID))
+}
+
+// VideoOverlayExpose tells an overlay that it has been exposed. This will redraw the current frame in the drawable even if the pipeline is PAUSED.
+func (e *Element) VideoOverlayExpose() {
+	C.gst_video_overlay_expose((*C.GstVideoOverlay)(unsafe.Pointer(e.GstElement)))
+}
+
+// VideoOverlayHandleEvents tells an overlay that it should handle events from the window system.
+// These events are forwarded upstream as navigation events. In some window system, events are not
+// propagated in the window hierarchy if a client is listening for them. This method allows you to
+// disable events handling completely from the GstVideoOverlay.
+func (e *Element) VideoOverlayHandleEvents(handleEvents bool) {
+	bInt := int(0)
+	if handleEvents {
+		bInt = 1
+	}
+	C.gst_video_overlay_handle_events((*C.GstVideoOverlay)(unsafe.Pointer(e.GstElement)), (C.gboolean)(bInt))
+}


### PR DESCRIPTION
Added functions to deal with GstVideoOverlay. This allows creating a pipeline that can be embedded into a GUI that is created by Go code. For example to create a video player in pure go.