### PR TITLE
Replace `bcopy` with `memmove`

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -31,7 +31,7 @@ func BufferNewAndAlloc(size uint) (gstBuffer *Buffer, err error) {
 
 func BufferNewWrapped(data []byte) (gstBuffer *Buffer, err error) {
 	Cdata := (*C.gchar)(unsafe.Pointer(C.malloc(C.size_t(len(data)))))
-	C.bcopy(unsafe.Pointer(&data[0]), unsafe.Pointer(Cdata), C.size_t(len(data)))
+	C.memmove(unsafe.Pointer(Cdata), unsafe.Pointer(&data[0]), C.size_t(len(data)))
 	CGstBuffer := C.X_gst_buffer_new_wrapped(Cdata, C.gsize(len(data)))
 	if CGstBuffer == nil {
 		err = errors.New("could not allocate and wrap a new GstBuffer")


### PR DESCRIPTION
This fixes a compatibility issue with windows which does not include a definition for `bcopy`. Based on https://stackoverflow.com/a/18330731 this should be equivalent.

Without the patch:

```bash
C:\Users\Nathan\projects\gst [master ≡ +1 ~0 -0 !]> go test ./...
# github.com/notedit/gst
.\buffer.go:34:2: could not determine kind of name for C.bcopy
FAIL    github.com/notedit/gst [build failed]
FAIL
```

With the patch:

```bash
C:\Users\Nathan\projects\gst [bugfix/windows +1 ~0 -0 !]> go test ./...
ok      github.com/notedit/gst  1.328s
```