### PR TITLE
(*element).SetObject: Add support for float64

### DIFF
--- a/element.go
+++ b/element.go
@@ -232,12 +232,16 @@ func (e *Element) SetObject(name string, value interface{}) {
 			cvalue = 0
 		}
 		C.X_gst_g_object_set_bool(e.GstElement, cname, C.gboolean(cvalue))
+	case float64:
+		C.X_gst_g_object_set_gdouble(e.GstElement, cname, C.gdouble(value.(float64)))
 	case *Caps:
 		caps := value.(*Caps)
 		C.X_gst_g_object_set_caps(e.GstElement, cname, caps.caps)
 	case *Structure:
 		structure := value.(*Structure)
 		C.X_gst_g_object_set_structure(e.GstElement, cname, structure.C)
+	default:
+		panic(fmt.Errorf("SetObject: don't know how to set value for type %T", value))
 	}
 }
 

--- a/gst.c
+++ b/gst.c
@@ -53,6 +53,10 @@ void X_gst_g_object_set_bool(GstElement *e, const gchar* p_name, gboolean p_valu
   g_object_set(G_OBJECT(e), p_name, p_value, NULL);
 }
 
+void X_gst_g_object_set_gdouble(GstElement *e, const gchar* p_name, gdouble p_value) {
+  g_object_set(G_OBJECT(e), p_name, p_value, NULL);
+}
+
 void X_gst_g_object_set_caps(GstElement *e, const gchar* p_name, const GstCaps *p_value) {
   g_object_set(G_OBJECT(e), p_name, p_value, NULL);
 }
@@ -74,7 +78,7 @@ void cb_new_pad(GstElement *element, GstPad *pad, gpointer data) {
 
 void X_g_signal_connect(GstElement* element, gchar* detailed_signal, guint64 callbackId) {
   printf("[ GST ] g_signal_connect called with signal %s\n", detailed_signal);
-  
+
   ElementUserData *d = calloc(1, sizeof(ElementUserData));
   d->callbackId = callbackId;
 
@@ -204,10 +208,10 @@ void X_gst_pipeline_set_latency(GstElement* element, GstClockTime clockTime) {
 
 
 GstFlowReturn X_gst_app_src_push_buffer(GstElement* element, void *buffer,int len) {
-  
+
   gpointer p = g_memdup(buffer, len);
   GstBuffer *data = gst_buffer_new_wrapped(p, len);
-  
+
   return gst_app_src_push_buffer(GST_APP_SRC(element), data);
 }
 

--- a/gst.h
+++ b/gst.h
@@ -25,6 +25,7 @@ extern void X_gst_g_object_set_string(GstElement *e, const gchar* p_name, gchar*
 extern void X_gst_g_object_set_int(GstElement *e, const gchar* p_name, gint p_value);
 extern void X_gst_g_object_set_uint(GstElement *e, const gchar* p_name, guint p_value);
 extern void X_gst_g_object_set_bool(GstElement *e, const gchar* p_name, gboolean p_value);
+extern void X_gst_g_object_set_gdouble(GstElement *e, const gchar* p_name, gdouble p_value);
 extern void X_gst_g_object_set_caps(GstElement *e, const gchar* p_name, const GstCaps *p_value);
 extern void X_gst_g_object_set(GstElement* e, const gchar* p_name, const GValue* p_value);
 extern void X_gst_g_object_set_structure(GstElement *e, const gchar* p_name, const GstStructure *p_value);


### PR DESCRIPTION
This allows us to set values for things like [`volume.volume`](https://gstreamer.freedesktop.org/documentation/volume/index.html?gi-language=c#volume:volume)

Additionally, panic when setting a value for a type that we don't support to make debugging easier.