### PR TITLE
Add support for gst_structure_get* for types supported by (*gst.Structure).SetValue(...)

### DIFF
--- a/structure.go
+++ b/structure.go
@@ -7,8 +7,9 @@ package gst
 import "C"
 
 import (
-	"runtime"
-	"unsafe"
+    "fmt"
+    "runtime"
+    "unsafe"
 )
 
 type Structure struct {
@@ -28,6 +29,67 @@ func NewStructure(name string) (structure *Structure) {
 	})
 
 	return
+}
+
+func errNoSuchField(t, name string) error {
+    return fmt.Errorf("structure does not have a %s named %s", t, name)
+}
+
+func (s *Structure) GetName() string {
+    return C.GoString(C.gst_structure_get_name(s.C))
+}
+
+func (s *Structure) GetBool(name string) (bool, error) {
+    var out C.gboolean
+
+    if C.FALSE == C.gst_structure_get_boolean(s.C, C.CString(name), &out) {
+        return false, errNoSuchField("bool", name)
+    }
+
+    if out == C.TRUE {
+        return true, nil
+    }
+
+    return false, nil
+}
+
+func (s *Structure) GetInt(name string) (int, error) {
+    var out C.gint
+
+    if C.FALSE == C.gst_structure_get_int(s.C, C.CString(name), &out) {
+        return 0, errNoSuchField("int", name)
+    }
+
+    return int(out), nil
+}
+
+func (s *Structure) GetInt64(name string) (int64, error) {
+    var out C.gint64
+
+    if C.FALSE == C.gst_structure_get_int64(s.C, C.CString(name), &out) {
+        return 0, errNoSuchField("int64", name)
+    }
+
+    return int64(out), nil
+}
+
+func (s *Structure) GetUint(name string) (uint, error) {
+    var out C.guint
+
+    if C.FALSE == C.gst_structure_get_uint(s.C, C.CString(name), &out) {
+        return 0, errNoSuchField("uint", name)
+    }
+
+    return uint(out), nil
+}
+
+func (s *Structure) GetString(name string) (string, error) {
+    out := C.gst_structure_get_string(s.C, C.CString(name))
+    if out == nil {
+        return "", errNoSuchField("string", name)
+    }
+
+    return C.GoString(out), nil
 }
 
 func (s *Structure) SetValue(name string, value interface{}) {


### PR DESCRIPTION
This allows users to access the structures that are attached to messages on the bus without having to parse / write a regular expression for `(*gst.Structure).ToString()`