### PR TITLE
Add Element.EndOfStream() support

### DIFF
--- a/element.go
+++ b/element.go
@@ -197,6 +197,18 @@ func (e *Element) GetClock() (gstClock *Clock) {
 	return
 }
 
+func (e *Element) EndOfStream() (err error) {
+	// EndOfStream signals that the appsrc will not receive any further
+	// input via PushBuffer and permits the pipeline to finish properly.
+
+	var gstReturn C.GstFlowReturn
+	gstReturn = C.gst_app_src_end_of_stream((*C.GstAppSrc)(unsafe.Pointer(e.GstElement)))
+	if gstReturn != C.GST_FLOW_OK {
+		err = errors.New("could not send end_of_stream")
+	}
+	return
+}
+
 func (e *Element) PushBuffer(data []byte) (err error) {
 
 	b := C.CBytes(data)


### PR DESCRIPTION
When using appsrc in push mode, gst requires the user to call `gst_app_src_end_of_stream()`. Otherwise the pipeline would block forever.

`gst_app_src_end_of_stream` is currently not wrapped/exposed in the Golang gst bindings. This PR adds it.

Previously, simply sending an EOS signal was supposed to be the solution. However, despite contradicting gstreamer code comments, sending the signal does not seem to be exactly the same as invoking the mentioned function. Specifically, sending the signal might lead to the pipeline finishing too early and therefore losing samples.

Fixes: https://github.com/notedit/gst/issues/23
Related: https://github.com/notedit/gst/issues/11 https://github.com/notedit/gst/pull/12 http://gstreamer-devel.966125.n4.nabble.com/How-to-handle-EOS-from-an-appsrc-to-ensure-all-frames-are-played-out-before-pipeline-closes-td4671225.html#a4671257 (Jan Alexander Steffens seems to be an [active contributor](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commits/master?author=Jan%20Alexander%20Steffens) at gstreamer upstream)