### PR TITLE
New value type for Element.SetObject

### DIFF
--- a/element.go
+++ b/element.go
@@ -312,6 +312,10 @@ func (e *Element) SetObject(name string, value interface{}) {
 	case *Structure:
 		structure := value.(*Structure)
 		C.X_gst_g_object_set_structure(e.GstElement, cname, structure.C)
+	case *Element:
+		element := value.(*Element)
+		C.X_gst_g_object_set_element(e.GstElement, cname, element.GstElement)
+
 	default:
 		panic(fmt.Errorf("SetObject: don't know how to set value for type %T", value))
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/artofey/gst
+module github.com/notedit/gst
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/notedit/gst
+module github.com/artofey/gst
 
 go 1.12

--- a/gst.c
+++ b/gst.c
@@ -65,6 +65,10 @@ void X_gst_g_object_set_structure(GstElement *e, const gchar* p_name, const GstS
   g_object_set(G_OBJECT(e), p_name, p_value, NULL);
 }
 
+void X_gst_g_object_set_element(GstElement *e, const gchar* p_name, const GstElement *p_value) {
+  g_object_set(G_OBJECT(e), p_name, p_value, NULL);
+}
+
 void X_gst_g_object_setv(GObject *object, guint n_properties, const gchar *names[], const GValue value[]) {
   //g_object_setv(object, n_properties, names, value);
 }

--- a/gst.h
+++ b/gst.h
@@ -29,6 +29,7 @@ extern void X_gst_g_object_set_gdouble(GstElement *e, const gchar* p_name, gdoub
 extern void X_gst_g_object_set_caps(GstElement *e, const gchar* p_name, const GstCaps *p_value);
 extern void X_gst_g_object_set(GstElement* e, const gchar* p_name, const GValue* p_value);
 extern void X_gst_g_object_set_structure(GstElement *e, const gchar* p_name, const GstStructure *p_value);
+extern void X_gst_g_object_set_element(GstElement *e, const gchar* p_name, const GstElement *p_value);
 extern void X_gst_g_object_setv(GObject* object, guint n_properties, const gchar* names[], const GValue value[]);
 extern void X_gst_g_pad_set_string(GstPad *e, const gchar* p_name, gchar* p_value);
 extern void X_gst_g_pad_set_int(GstPad *e, const gchar* p_name, gint p_value);


### PR DESCRIPTION
Without these changes it is not possible to use the [**splitmuxsink**](https://gstreamer.freedesktop.org/documentation/multifile/splitmuxsink.html?gi-language=c#splitmuxsink:muxer) plugin 